### PR TITLE
removed note on non-default homebrew installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,6 @@ $ brew install bats-file
 from the core tap will be installed automatically for you, with any of
 the two previous commands.*
 
-*__Note:__ Homebrew installs packages in a system-wide `/usr/local`
-prefix by default. This is encouraged praxis when using `brew`, but
-optional. See
-[Alternative Installs](https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#alternative-installs)
-from the Homebrew documentation for details.*
-
-
 ## Git submodule
 
 If your project uses Git, the recommended method of installation is via


### PR DESCRIPTION
This note was a bit weird. It seemed to imply that one could customize where homebrew installed its packages. However, the referenced homebrew documentation is about where homebrew _itself_ is installed. The packages that homebrew then installs are relative to the homebrew install location. So once homebrew itself is installed, it's really too late to customize where brew packages go. And since the homebrew directions basically assume a pre-existing homebrew installation, I don't think it makes sense to even both noting the alternative install bit.
